### PR TITLE
config(repo): set up '.gitignore' to prevent polluting remote repository (ref #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# local workspace state
+.obsidian/workspace.json
+.obsidian/workspace-mobile.json
+.obsidian/workspace
+
+# local cache and history
+.obsidian/cache/
+.trash/
+
+# OS generated files (cross-platform)
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ethhumbs.db
+Thumbs.db
+desktop.ini
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Set up `.gitignore` to prevent polluting remote repository (#3).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # obsidian-vault-template
 
 ### A clean, structured Obsidian vault template using the PARA methodology. Designed for clarity, focus, and zero-friction organization.
+


### PR DESCRIPTION
## Objective
Set up `.gitignore` to prevent local machine configuration and cache from polluting the remote repository.

## Related Issue
Closes #3 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.