### PR TITLE
refactor(security): corrected project name (ref #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 - Refactor `README.md` typography, title, and overview text (#15).
 - Refactor contribution branch naming examples (#16).
+- Refactor `SECURITY.md` project name (#21).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability within MainframeForge, please send an e-mail to **dusan.mitrovic.developer@gmail.com**.
+If you discover a security vulnerability within the Obsidian Vault Starter Template, please send an e-mail to **dusan.mitrovic.developer@gmail.com**.
 
 We will respond within 48 hours. **Do not open public issues for security exploits.**
 


### PR DESCRIPTION
## Objective
Change the residual `MainframeForge` project name to `Obsidian Vault Starter Template`.

## Related Issue
Closes #21 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

