### PR TITLE
docs(readme): add indexing convention clause to the docs (ref #23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add MIT license to the repository (#13).
 - Implement Quick Start section (#15).
 - Enhance `README.md` with status badges (#19).
+- Add indexing convention clause to the docs (#23).
 ### Changes
 - Refactor `README.md` typography, title, and overview text (#15).
 - Refactor contribution branch naming examples (#16).

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To use the template, you only need `vault/` directory.
 - `99.system/`    - Vault infrastructure (templates, scripts, metadata).
 
 ### Conventions
+- **Indexing:** `[00-99].` (e.g., `01.`).
 - **Naming Folders:** `snake_case`.
 - **Naming Files:** `kebab-case`.
 


### PR DESCRIPTION
## Objective
 Add an indexing convention clause to the `README.md` file.

<details>
  <summary>
  Expand to see the new indexing clause
  </summary>
  <img width="302" height="132" alt="image" src="https://github.com/user-attachments/assets/f540098f-2710-4ccc-af28-7005a4341f3d" />
</details>

## Related Issue
Closes #23 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

