### PR TITLE
fix(gitignore): typo (ref #24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ vault/.trash/
 .Spotlight-V100
 .Trashes
 Icon?
-ethhumbs.db
+ehthumbs.db
 Thumbs.db
 desktop.ini
 $RECYCLE.BIN/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,4 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor `README.md` typography, title, and overview text (#15).
 - Refactor contribution branch naming examples (#16).
 - Refactor `SECURITY.md` project name (#21).
+### Fixes
+- Typo `ethhumbs.db` in `.gitignore` (#24).
 


### PR DESCRIPTION
## Objective
Fixed typo `ethhumbs.db` in `.gitignore` file.

## Related Issue
Fixes #24 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

