### PR TITLE
fix(repo): task issue template missing commit types (ref #35)

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -8,10 +8,14 @@ assignees: ''
 
 <!--
 If this is not a feature, change the title prefix and label:
-- config: Plugin settings, GitHub config, metadata.
 - docs: Documentation updates.
-- refactor: Restructuring folders/files.
-- style: Formatting fixes.
+- chore: Maintenance tasks.
+- refactor: Restructuring code without behavior changes.
+- style: Formatting adjustments (no code change).
+- build: Build system or external dependency changes.
+- ci: CI configuration files and scripts.
+- perf: Performance optimizations.
+- test: Adding or upgrading tests.
 -->
 
 ### Context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - Typo `ethhumbs.db` in `.gitignore` (#24).
+- Task issue template missing commit types (#35).
 


### PR DESCRIPTION
## Objective
Add missing commit types to the task issue template.

<details>
  <summary>Expand for visual context</summary>
  <img width="475" height="188" alt="image" src="https://github.com/user-attachments/assets/a01a3987-e477-449d-9986-805723797802" />
</details>

## Related Issue
Closes #35 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

