### PR TITLE
docs(contributing): add revert commit type and breaking change contribution guide (ref #36)

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -16,6 +16,7 @@ If this is not a feature, change the title prefix and label:
 - ci: CI configuration files and scripts.
 - perf: Performance optimizations.
 - test: Adding or upgrading tests.
+- revert: Undoing the changes of a specific commit.
 -->
 
 ### Context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement Quick Start section (#15).
 - Enhance `README.md` with status badges (#19).
 - Add indexing convention clause to the docs (#23).
+- Add revert commit type and breaking change contribution guide (#36).
 
 ### Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Direct pushes to `main` branch are prohibited.
   - `ci:` CI configuration files and scripts.
   - `perf:` Performance optimizations.
   - `test:` Adding or upgrading tests.
+  - `revert:` Undoing the changes of a specific commit.
 
 **Format:**
 ```
@@ -34,6 +35,8 @@ Direct pushes to `main` branch are prohibited.
 
 [optional footer(s)]
 ```
+> [!IMPORTANT]
+> Append `!` to the type for breaking changes (e.g., `refactor(core)!: ...`).
 
 3. **Pull Requests:** All changes must be reviewed and merged via PR.
 


### PR DESCRIPTION
## Objective
Add the missing `revert` commit type and breaking change guidance to the contribution guide.

<details>
  <summary>Expand for visual context</summary>
  <img width="586" height="273" alt="image" src="https://github.com/user-attachments/assets/006e82df-0739-4306-b00e-eb5249b6718b" />
</details>

## Related Issue
Closes #36 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

