### PR TITLE
feat(installer): implement bash install script for Linux OS (ref #32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhance `README.md` with status badges (#19).
 - Add indexing convention clause to the docs (#23).
 - Add revert commit type and breaking change contribution guide (#36).
+- Implement bash `install.sh` script for Linux OS (#32).
 
 ### Changes
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Initialize Obsidian Vault Starter Template
+# Usage: ./install.sh [-t|--tag TAG] [-n|--name VAULT_NAME] [-i|--info]
+
+set -euo pipefail
+
+readonly REPOSITORY="dusanmitrovic-dev/obsidian-vault-template"
+readonly API_LATEST="https://api.github.com/repos/${REPOSITORY}/releases/latest"
+SCR_TMP_DIR=""
+
+cleanup() {
+  [[ -n "${SCR_TMP_DIR:-}" ]] && rm -rf "$SCR_TMP_DIR";
+}
+
+trap cleanup EXIT
+
+log() {
+  echo -e "\033[0;34m==>\033[0m $1";
+}
+
+success() {
+  echo -e "\033[0;32m==>\033[0m $1";
+}
+
+error() {
+  echo -e "\033[0;31mERROR:\033[0m $1" >&2; exit 1;
+}
+
+main() {
+  local tag="latest"
+  local name="vault"
+  local info_only=false
+  
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -t|--tag) tag="$2"; shift 2 ;;
+      --tag=*) tag="${1#*=}"; shift 1 ;;
+      -n|--name) name="$2"; shift 2 ;;
+      --name=*) name="${1#*=}"; shift 1 ;;
+      -i|--info) info_only=true; shift 1 ;;
+      -h|--help) echo "Usage: ./install.sh [-t|--tag TAG] [-n|--name VAULT_NAME] [-i|--info]"; exit 0 ;;
+      *) error "Unknown option: $1" ;;
+    esac
+  done
+
+  if [[ "$tag" = "latest" ]]; then
+    local latest=$(curl -s "${API_LATEST}" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' || true)
+    tag="${latest:-main}"
+  else
+    [[ "$tag" != "main" ]] && [[ "$tag" != v* ]] && tag="v$tag"
+  fi
+
+  if [ "$info_only" = true ]; then echo "$tag"; exit 0; fi
+
+  for cmd in curl tar grep sed; do command -v "${cmd}" >/dev/null 2>&1 || error "Command '${cmd}' missing."; done
+    [ -d "$name" ] && error "Directory './$name' already exists."
+
+  SCR_TMP_DIR=$(mktemp -d)
+  local url="https://github.com/${REPOSITORY}/archive/refs/$( [[ "$tag" == "main" ]] && echo "heads/main" || echo "tags/$tag" ).tar.gz"
+
+  log "Downloading ${tag}..."
+  curl -fsSL "$url" -o "${SCR_TMP_DIR}/archive.tar.gz" || error "Download failed. Check the network or tag name."
+  tar -xzf "${SCR_TMP_DIR}/archive.tar.gz" -C "${SCR_TMP_DIR}" || error "Extraction failed."
+
+  local vault_src
+  vault_src=$(find "${SCR_TMP_DIR}" -type d -name "vault" | head -n 1)
+
+  [ -z "${vault_src:-}" ] && error "Vault source not found in archive."
+
+  mv "$vault_src" "./${name}" || error "Failed to move vault to target directory."
+  success "Installed ${tag} to ./${name}"
+
+main "$@"
+


### PR DESCRIPTION
## Objective
Implemented a one-liner `install.sh` script that downloads the latest stable release or the specified version to the current working directory (pwd) from which the command is called. Ability to rename `vault` directory, target specific tag version, and get info. The install script will only extract the `vault/` directory.

<details>
  <summary>Expand for visual context</summary>
  <img width="291" height="69" alt="image" src="https://github.com/user-attachments/assets/92bbbf78-0362-47a4-8afb-ef453e3e7a04" />
</details>

## Related Issue
Closes #32 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

