### PR TITLE
fix(installer): missing closing bracket in bash install script (ref #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,4 +34,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Typo `ethhumbs.db` in `.gitignore` (#24).
 - Task issue template missing commit types (#35).
+- Missing closing bracket in bash install script (#40).
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,6 +69,7 @@ main() {
 
   mv "$vault_src" "./${name}" || error "Failed to move vault to target directory."
   success "Installed ${tag} to ./${name}"
+}
 
 main "$@"
 


### PR DESCRIPTION
## Objective
Missing closing bracket in `scripts/install.sh` script.

<details>
  <summary>Expand for visual context</summary>
  <img width="951" height="123" alt="image" src="https://github.com/user-attachments/assets/9fcb0095-e2af-4cef-b04b-28d2fcef852d" />
  <img width="343" height="86" alt="image" src="https://github.com/user-attachments/assets/26601809-f145-43ed-95ea-5aa168585603" />
</details>

## Related Issue
Closes #40 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

