### PR TITLE
feat(install): migrate installer endpoint to custom domain (ref #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0] - 2026-04-19
 
 ### Added
+
 - Add dynamic release version badge (#46).
 - Add automated latest tag workflow (#48).
 - Implement inbox buffer logic for new notes (#50).
@@ -17,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement daily notes configuration (#54).
 - Implement templates configuration (#56).
 - Add daily ledger template note (#58).
+
+### Changes
+
+- Migrate installer endpoint to custom domain: `vault.mainframeforge.com` (#62).
 
 ## [0.1.0] - 2026-03-31
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use the template, you only need the `vault/` directory.
 #### Linux
 
 ```
-curl -sSL https://raw.githubusercontent.com/dusanmitrovic-dev/obsidian-vault-template/latest/scripts/install.sh | bash
+curl -sSL vault.mainframeforge.com | bash
 ```
 
 For advanced installer configuration options, please refer to the [Installation](https://github.com/dusanmitrovic-dev/obsidian-vault-template/wiki/installation) wiki page.


### PR DESCRIPTION
## Objective
Migrate the installer endpoint to the custom domain: `vault.mainframeforge.com`.

<details>
  <summary>Expand for visual context</summary>
  [Paste image or logs here]
</details>

## Related Issue
Closes #62 

## Verification
- [ ] Acceptance Criteria met.
- [ ] Style Guide respected.
- [ ] Documentation updated.

