### PR TITLE
fix(install): enforce HTTPS protocol for branded installer endpoint (ref #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Migrate installer endpoint to custom domain: `vault.mainframeforge.com` (#62).
+
+### Fixes
+
+- Enforce HTTPS protocol for branded installer endpoint (#64).
+
 ## [0.2.0] - 2026-04-19
 
 ### Added
@@ -18,10 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement daily notes configuration (#54).
 - Implement templates configuration (#56).
 - Add daily ledger template note (#58).
-
-### Changes
-
-- Migrate installer endpoint to custom domain: `vault.mainframeforge.com` (#62).
 
 ## [0.1.0] - 2026-03-31
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To use the template, you only need the `vault/` directory.
 #### Linux
 
 ```
-curl -sSL vault.mainframeforge.com | bash
+curl -sSL https://vault.mainframeforge.com | bash
 ```
 
 For advanced installer configuration options, please refer to the [Installation](https://github.com/dusanmitrovic-dev/obsidian-vault-template/wiki/installation) wiki page.


### PR DESCRIPTION
## Objective
Enforce HTTPS protocol on the custom domain installer URL.

<details>
  <summary>Expand for visual context</summary>
  <img width="868" height="143" alt="image" src="https://github.com/user-attachments/assets/8483dd41-5835-4bdf-830a-67762c0903dd" />
</details>

## Related Issue
Closes #64 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

