### PR TITLE
chore(issues): remove default docs label from issues templates (ref #69)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Report a system defect, error or typo
 title: 'fix: '
-labels: fix, docs
+labels: fix
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,7 +2,7 @@
 name: Release
 about: Checklist for cutting a new version
 title: 'chore: prepare and cut release vX.Y.Z'
-labels: chore, docs
+labels: chore
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -2,7 +2,7 @@
 name: Task / Enhancement
 about: Propose a new feature, config change, docs update, style change, or refactor
 title: 'feat: '
-labels: feat, docs
+labels: feat
 assignees: ''
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Prune redundant `.gitkeep` files from parent directories (#66).
+- Remove default docs label from issues templates (#69).
 
 ### Fixes
 


### PR DESCRIPTION
## Objective
Remove default docs label from issue templates.

## Related Issue
Closes #69 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

