### PR TITLE
style(installer): solve misleading indentation (ref #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - Migrate installer endpoint to custom domain: `vault.mainframeforge.com` (#62).
+- Update supported versions table in security policy (#68).
+- Solve misleading indentation in bash installer script (#70).
 
 ### Removed
 
@@ -18,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - Enforce HTTPS protocol for branded installer endpoint (#64).
-- Update supported versions table in security policy (#68).
 
 ## [0.2.0] - 2026-04-19
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,7 +53,7 @@ main() {
   if [ "$info_only" = true ]; then echo "$tag"; exit 0; fi
 
   for cmd in curl tar grep sed; do command -v "${cmd}" >/dev/null 2>&1 || error "Command '${cmd}' missing."; done
-    [ -d "$name" ] && error "Directory './$name' already exists."
+  [ -d "$name" ] && error "Directory './$name' already exists."
 
   SCR_TMP_DIR=$(mktemp -d)
   local url="https://github.com/${REPOSITORY}/archive/refs/$( [[ "$tag" == "main" ]] && echo "heads/main" || echo "tags/$tag" ).tar.gz"


### PR DESCRIPTION
## Objective
Solve misleading indentation in the bash installer script.

<details>
  <summary>Expand for visual context</summary>
  <img width="229" height="66" alt="image" src="https://github.com/user-attachments/assets/13a1a26b-5543-46b7-8d25-213c344d732f" />
</details>

## Related Issue
Closes #70 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

