### PR TITLE
feat(appearance): add CSS snippet to fix file explorer underscore alignment (ref #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add CSS snippet to fix file explorer underscore alignment (#71).
+
 ### Changes
 
 - Migrate installer endpoint to custom domain: `vault.mainframeforge.com` (#62).

--- a/vault/.obsidian/appearance.json
+++ b/vault/.obsidian/appearance.json
@@ -1,4 +1,6 @@
 {
-
+  "enabledCssSnippets": [
+    "file-explorer-font"
+  ]
 }
 

--- a/vault/.obsidian/snippets/file-explorer-font.css
+++ b/vault/.obsidian/snippets/file-explorer-font.css
@@ -1,0 +1,6 @@
+.workspace-leaf-content[data-type="file-explorer"] .nav-folder-title-content,
+.workspace-leaf-content[data-type="file-explorer"] .nav-file-title-content {
+  font-family: "Ubuntu", "Inter", "Cantarell", "Noto Sans", "Segoe UI", "Roboto", system-ui, sans-serif;
+  font-size: 0.95em;
+}
+


### PR DESCRIPTION
## Objective
Add a CSS snippet to fix the file explorer underscore alignment.

<details>
  <summary>Expand for visual context</summary>
  <img width="277" height="302" alt="image" src="https://github.com/user-attachments/assets/3ef94efd-dd6b-40a2-93dc-b98c8f79966c" />
</details>

## Related Issue
Closes #71 

## Verification
- [x] Acceptance Criteria met.
- [x] Style Guide respected.
- [x] Documentation updated.

